### PR TITLE
Fix caption below the images

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,40 +27,50 @@ layout: default
     <div class="col-md-2 col-md-offset-1">
       <div class="part">
         <a href="/about">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Icon-round-Question_mark.jpg/240px-Icon-round-Question_mark.jpg"/><br/>
-          <span class="btn" >Learn More</span>
+          <span>
+            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Icon-round-Question_mark.jpg/240px-Icon-round-Question_mark.jpg"/>
+          </span>
+          <span class="btn">Learn More</span>
         </a>
       </div>
     </div>
     <div class="col-md-2">
       <div class="part">
         <a href="{{ site.baseurl_api }}/api">
-          <img src="/img/icon-swagger.png"/><br/>
-          <span class="btn" >Explore our API</span>
+          <span>
+            <img src="/img/icon-swagger.png"/>
+          </span>
+          <span class="btn">Explore our API</span>
         </a>
       </div>
     </div>
     <div class="col-md-2">
       <div class="part">
         <a href="/blog">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/d/d9/Rss-feed.svg"/><br/>
-          <span class="btn" >Read our Blog</span>
+          <span>
+            <img src="https://upload.wikimedia.org/wikipedia/commons/d/d9/Rss-feed.svg"/>
+          </span>
+          <span class="btn">Read our Blog</span>
         </a>
       </div>
     </div>
     <div class="col-md-2">
       <div class="part">
         <a href="{{ site.baseurl_api }}/schema">
-          <img src="/img/icon-schema.png"/><br/>
-          <span class="btn" >Explore our Schema</span>
+          <span>
+            <img src="/img/icon-schema.png"/>
+          </span>
+          <span class="btn">Explore our Schema</span>
         </a>
       </div>
     </div>
     <div class="col-md-2">
       <div class="part">
         <a href="http://infolis.gesis.org/ldf/">
-          <img src="/img/icon-ldf.png"/><br/>
-          <span class="btn" >Linked Data Fragments</span>
+          <div>
+            <img src="/img/icon-ldf.png"/>
+          </div>
+          <span class="btn">Linked Data Fragments</span>
         </a>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ layout: default
     <div class="col-md-2 col-md-offset-1">
       <div class="part">
         <a href="/about">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Icon-round-Question_mark.jpg/240px-Icon-round-Question_mark.jpg"/>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Icon-round-Question_mark.jpg/240px-Icon-round-Question_mark.jpg"/><br/>
           <span class="btn btn-default" >Learn More</span>
         </a>
       </div>
@@ -35,7 +35,7 @@ layout: default
     <div class="col-md-2">
       <div class="part">
         <a href="{{ site.baseurl_api }}/api">
-          <img src="/img/icon-swagger.png"/>
+          <img src="/img/icon-swagger.png"/><br/>
           <span class="btn btn-default" >Explore our API</span>
         </a>
       </div>
@@ -43,7 +43,7 @@ layout: default
     <div class="col-md-2">
       <div class="part">
         <a href="/blog">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/d/d9/Rss-feed.svg"/>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/d/d9/Rss-feed.svg"/><br/>
           <span class="btn btn-default" >Read our Blog</span>
         </a>
       </div>
@@ -51,7 +51,7 @@ layout: default
     <div class="col-md-2">
       <div class="part">
         <a href="{{ site.baseurl_api }}/schema">
-          <img src="/img/icon-schema.png"/>
+          <img src="/img/icon-schema.png"/><br/>
           <span class="btn btn-default" >Explore our Schema</span>
         </a>
       </div>
@@ -59,7 +59,7 @@ layout: default
     <div class="col-md-2">
       <div class="part">
         <a href="http://infolis.gesis.org/ldf/">
-          <img src="/img/icon-ldf.png"/>
+          <img src="/img/icon-ldf.png"/><br/>
           <span class="btn btn-default" >Linked Data Fragments</span>
         </a>
       </div>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ layout: default
       <div class="part">
         <a href="/about">
           <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Icon-round-Question_mark.jpg/240px-Icon-round-Question_mark.jpg"/><br/>
-          <span class="btn btn-default" >Learn More</span>
+          <span class="btn" >Learn More</span>
         </a>
       </div>
     </div>
@@ -36,7 +36,7 @@ layout: default
       <div class="part">
         <a href="{{ site.baseurl_api }}/api">
           <img src="/img/icon-swagger.png"/><br/>
-          <span class="btn btn-default" >Explore our API</span>
+          <span class="btn" >Explore our API</span>
         </a>
       </div>
     </div>
@@ -44,7 +44,7 @@ layout: default
       <div class="part">
         <a href="/blog">
           <img src="https://upload.wikimedia.org/wikipedia/commons/d/d9/Rss-feed.svg"/><br/>
-          <span class="btn btn-default" >Read our Blog</span>
+          <span class="btn" >Read our Blog</span>
         </a>
       </div>
     </div>
@@ -52,7 +52,7 @@ layout: default
       <div class="part">
         <a href="{{ site.baseurl_api }}/schema">
           <img src="/img/icon-schema.png"/><br/>
-          <span class="btn btn-default" >Explore our Schema</span>
+          <span class="btn" >Explore our Schema</span>
         </a>
       </div>
     </div>
@@ -60,7 +60,7 @@ layout: default
       <div class="part">
         <a href="http://infolis.gesis.org/ldf/">
           <img src="/img/icon-ldf.png"/><br/>
-          <span class="btn btn-default" >Linked Data Fragments</span>
+          <span class="btn" >Linked Data Fragments</span>
         </a>
       </div>
     </div>


### PR DESCRIPTION
Currently the caption is sometimes below and sometimes besides the images, depending on the screen width. E.g.

![screen1](https://cloud.githubusercontent.com/assets/5199995/11171289/cfa64a26-8bec-11e5-9725-c591f4c4bad8.jpg)
![screen2](https://cloud.githubusercontent.com/assets/5199995/11171290/cfceaca0-8bec-11e5-89fc-f70ce30c4ff0.jpg)

I think it is best to always show the captions below the images and therefore also show the images besides each other as long as possible before switching to the horizontal layout. This PR will do that.
